### PR TITLE
Add ToString overrides to Card subclasses.

### DIFF
--- a/QUEST/Assets/script/AllyCard.cs
+++ b/QUEST/Assets/script/AllyCard.cs
@@ -26,4 +26,10 @@ public class AllyCard : AdventureCard
 		_asset = asset;
 	}
 
+	// ToString Override for nicer printing.
+	public override string ToString(){
+		return "Ally card:\nName: " + _name + "\nPower: " + _power + "\nBid: " + _bid + "\nBonus Power: " + _bonusPower + 
+			"\nBonus Bid: " + _bonusBid + "\nQuest Condition: " + _questCondition + "\nAlly Condition: " + _allyCondition + 
+			"\nSpecial: " + _special + "\nAsset: " + _asset;
+	}
 }

--- a/QUEST/Assets/script/EventCard.cs
+++ b/QUEST/Assets/script/EventCard.cs
@@ -11,4 +11,9 @@ public class EventCard : StoryCard
     public EventCard(string conditions){
         conditions = _conditions;
     }
+
+	// ToString Override for nicer printing.
+	public override string ToString(){
+		return "Event card:\nName: " + _name + "\nConditions: " + _conditions;
+	}
 }

--- a/QUEST/Assets/script/FoeCard.cs
+++ b/QUEST/Assets/script/FoeCard.cs
@@ -16,4 +16,10 @@ public class FoeCard : AdventureCard
 		_hiPower = hiPower;
 		_special = special;
 	}
+
+	// ToString Override for nicer printing.
+	public override string ToString(){
+		return "Foe card:\nName: " + _name + "\nLow Power: " + _loPower + "\nHigh Power: " + _hiPower +
+			"/nSpecial" + _special;
+	}
 }

--- a/QUEST/Assets/script/QuestCard.cs
+++ b/QUEST/Assets/script/QuestCard.cs
@@ -17,4 +17,9 @@ public class QuestCard : StoryCard
 		_featuredFoe = featuredFoe;
 	}
 
+	// ToString Override for nicer printing.
+	public override string ToString(){
+		return "Quest card:\nName: " + _name + "\nStages: " + _stages + "\nFeatured Foe: " + _featuredFoe;
+	}
+
 }

--- a/QUEST/Assets/script/TournamentCard.cs
+++ b/QUEST/Assets/script/TournamentCard.cs
@@ -12,4 +12,9 @@ public class TournamentCard : StoryCard
 		_name = name;
 		_shields = shields;
 	}
+
+	// ToString Override for nicer printing.
+	public override string ToString(){
+		return "Tournament card:\nName: " + _name + "\nShields: " + _shields;
+	}
 }

--- a/QUEST/Assets/script/WeaponCard.cs
+++ b/QUEST/Assets/script/WeaponCard.cs
@@ -14,4 +14,9 @@ public class WeaponCard : AdventureCard
 		_power = power;
 		_asset = asset;
 	}
+
+	// ToString Override for nicer printing.
+	public override string ToString(){
+		return "Weapon card:\nName: " + _name + "\nPower: " + _power + "\nAsset: " + _asset;
+	}
 }


### PR DESCRIPTION
I've added `ToString` overrides to many of the card subclasses so that we can simply print them and see all the information for the current card. This should make testing easier in the future.

As we continue to develop they'll probably have to be added to or changed, or more many have to be added to new card subclasses.