### PR TITLE
Store Card GameObject's and add ability to flip cards.

### DIFF
--- a/QUEST/Assets/script/Card.cs
+++ b/QUEST/Assets/script/Card.cs
@@ -4,12 +4,23 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
  
-public abstract class Card : MonoBehaviour{
+public abstract class Card : MonoBehaviour {
 
-	public Transform oldPosition = null; 	//Old Position of the card on the board
+	public Transform oldPosition = null;     //Old Position of the card on the board
 
 	protected string _asset;
 	protected string _name;
+	protected bool _flipped = false;
+	protected GameObject _obj;
+
+	public GameObject obj {
+		get{
+			return this._obj;
+		}
+		set{
+			this._obj = value;
+		}
+	}
 
 	public string name {
 		get{
@@ -28,6 +39,26 @@ public abstract class Card : MonoBehaviour{
 			this._asset = value;
 		}
 	}
-		
-}
 
+	public bool flipped{
+		get{
+			return this._flipped;
+		}
+		set{
+			this._flipped = value;
+		}
+	}
+
+	// Flip a card over.
+	public void flipCard(){
+		_flipped = !_flipped;
+		Sprite card_image;
+		if(_flipped){
+			card_image = Resources.Load<Sprite>("card_image/special/backOfCard");
+		} else {
+			card_image = Resources.Load<Sprite>(this.asset);
+		}
+		_obj.GetComponent<Image>().sprite = card_image;
+	}
+
+}

--- a/QUEST/Assets/script/Game.cs
+++ b/QUEST/Assets/script/Game.cs
@@ -537,6 +537,11 @@ public class Game : MonoBehaviour {
 			//Debug.Log(card);
 			CardUI.gameObject.GetComponent<Image>().sprite = card;
 			CardUI.transform.SetParent(Hand.transform);
+
+			// Set the cards obj to it's UI.
+			// NOTE: There is probably a better built in Unity way to do this,
+			// if so, we should definitely swap it out.
+			currCard.obj = CardUI;
 		}
 	}
 


### PR DESCRIPTION
This links that actual Card GameObject's with the individual Card objects. It does this by setting a Card's `_obj` property. There might be a better built in Unity way to do this, and if that's the case, we should swap it out.

It also adds the ability to flip a card, which will change it's sprite to the `backOfCard.png` image. This currently isn't used, but now Cards can be flipped by calling `someCard.flipCard()`.