### PR TITLE
Fix card drag and flip cards on player switch.

### DIFF
--- a/QUEST/Assets/script/Card.cs
+++ b/QUEST/Assets/script/Card.cs
@@ -50,8 +50,8 @@ public abstract class Card : MonoBehaviour {
 	}
 
 	// Flip a card over.
-	public void flipCard(){
-		_flipped = !_flipped;
+	public void flipCard(bool f){
+		_flipped = f;
 		Sprite card_image;
 		if(_flipped){
 			card_image = Resources.Load<Sprite>("card_image/special/backOfCard");

--- a/QUEST/Assets/script/CardArea.cs
+++ b/QUEST/Assets/script/CardArea.cs
@@ -37,14 +37,18 @@ public class CardArea :  MonoBehaviour, IDropHandler, IPointerEnterHandler, IPoi
 		set;
 	}
 
-	public void removeCard(Card card){
-		for (int i = 0; i < _cards.Count; i++) {
-			if (_cards[i].name == card.name) {
-				_cards.RemoveAt (i);
-				break;
+	// Remove and return from card area.
+	public Card removeCard(Card card){
+		for (int i = 0; i < _cards.Count; i++){
+			if (_cards[i].name == card.name){
+				Card c = _cards[i];
+				_cards.RemoveAt(i);
+				return c;
 			}
 		}
+		return null;
 	}
+
 	public void addCard(Card card){
 		_cards.Add(card);
 	}
@@ -57,25 +61,24 @@ public class CardArea :  MonoBehaviour, IDropHandler, IPointerEnterHandler, IPoi
 	void Update () {	
 	}
 
-	//When a card is dropped
+	// When a card is dropped
 	public void OnDrop(PointerEventData eventData){
-		//Debug.Log(eventData.pointerDrag.name + " Drop to "+ gameObject.name);
 		Card currCard = eventData.pointerDrag.GetComponent<Card>();
-		if(currCard!=null){
-			_cards.Add(currCard);
-			//Debug.Log(_cards.Count);
-			///for(int i = 0 ; i < _cards.Count; i++){
-			//	Debug.Log(_cards[i].name);
-			//}
-			currCard.oldPosition.GetComponent<CardArea>().removeCard(currCard);
+		if(currCard != null){
+			// Remove the card from the card area.
+			Card c = currCard.oldPosition.GetComponent<CardArea>().removeCard(currCard);
+			// Add the removed card to the new card area.
+			_cards.Add(c);
+			// Move the actual card.
 			currCard.oldPosition= this.transform;
 		}
 	}
 
-	//Listener for when a mouse enter
+	// Listener for when a mouse enter
 	public void OnPointerEnter(PointerEventData eventData){
 	}
-	//Listener when a mouse exits
+
+	// Listener when a mouse exits
 	public void OnPointerExit(PointerEventData eventData){
 	}
 

--- a/QUEST/Assets/script/Deck.cs
+++ b/QUEST/Assets/script/Deck.cs
@@ -109,14 +109,14 @@ public class Deck{
 		} else if (type.Equals ("Story")) {
 			//WHEN ADDING FEATURED FOE * means all
 			// Fill the deck with story cards.
-			addQuest("Search for the Holy Grail", 5, "*", "card_image/quest/questCard9", 1);
-			addQuest("Test of the Green Knight", 4, "Green Knight", "card_image/quest/questCard10", 1);
-			addQuest("Search for the Questing Beast", 4, "", "card_image/quest/questCard5", 1);
-			addQuest("Defend the Queen's Honor", 4, "*", "card_image/quest/questCard6", 1);
-			addQuest("Rescue the Fair Maiden", 3, "Black Knight", "card_image/quest/questCard8", 1);
-			addQuest("Journey Through the Enchanted Forest", 3, "Evil Knight", "card_image/quest/questCard1", 1);
-			addQuest("Vanquish King Arthur's Enemies", 3, "", "card_image/quest/questCard2", 2);
-			addQuest("Slay the Dragon", 3, "Dragon", "card_image/quest/questCard7", 1);
+			//addQuest("Search for the Holy Grail", 5, "*", "card_image/quest/questCard9", 1);
+			//addQuest("Test of the Green Knight", 4, "Green Knight", "card_image/quest/questCard10", 1);
+			//addQuest("Search for the Questing Beast", 4, "", "card_image/quest/questCard5", 1);
+			//addQuest("Defend the Queen's Honor", 4, "*", "card_image/quest/questCard6", 1);
+			//addQuest("Rescue the Fair Maiden", 3, "Black Knight", "card_image/quest/questCard8", 1);
+			//addQuest("Journey Through the Enchanted Forest", 3, "Evil Knight", "card_image/quest/questCard1", 1);
+			//addQuest("Vanquish King Arthur's Enemies", 3, "", "card_image/quest/questCard2", 2);
+			//addQuest("Slay the Dragon", 3, "Dragon", "card_image/quest/questCard7", 1);
 			addQuest("Boar Hunt", 2, "Boar", "card_image/quest/questCard4", 2);
 			addQuest("Repel the Saxxon Raiders", 2, "Saxon", "card_image/quest/questCard3", 2);
 

--- a/QUEST/Assets/script/Deck.cs
+++ b/QUEST/Assets/script/Deck.cs
@@ -109,14 +109,14 @@ public class Deck{
 		} else if (type.Equals ("Story")) {
 			//WHEN ADDING FEATURED FOE * means all
 			// Fill the deck with story cards.
-			//addQuest("Search for the Holy Grail", 5, "*", "card_image/quest/questCard9", 1);
-			//addQuest("Test of the Green Knight", 4, "Green Knight", "card_image/quest/questCard10", 1);
-			//addQuest("Search for the Questing Beast", 4, "", "card_image/quest/questCard5", 1);
-			//addQuest("Defend the Queen's Honor", 4, "*", "card_image/quest/questCard6", 1);
-			//addQuest("Rescue the Fair Maiden", 3, "Black Knight", "card_image/quest/questCard8", 1);
-			//addQuest("Journey Through the Enchanted Forest", 3, "Evil Knight", "card_image/quest/questCard1", 1);
-			//addQuest("Vanquish King Arthur's Enemies", 3, "", "card_image/quest/questCard2", 2);
-			//addQuest("Slay the Dragon", 3, "Dragon", "card_image/quest/questCard7", 1);
+			addQuest("Search for the Holy Grail", 5, "*", "card_image/quest/questCard9", 1);
+			addQuest("Test of the Green Knight", 4, "Green Knight", "card_image/quest/questCard10", 1);
+			addQuest("Search for the Questing Beast", 4, "", "card_image/quest/questCard5", 1);
+			addQuest("Defend the Queen's Honor", 4, "*", "card_image/quest/questCard6", 1);
+			addQuest("Rescue the Fair Maiden", 3, "Black Knight", "card_image/quest/questCard8", 1);
+			addQuest("Journey Through the Enchanted Forest", 3, "Evil Knight", "card_image/quest/questCard1", 1);
+			addQuest("Vanquish King Arthur's Enemies", 3, "", "card_image/quest/questCard2", 2);
+			addQuest("Slay the Dragon", 3, "Dragon", "card_image/quest/questCard7", 1);
 			addQuest("Boar Hunt", 2, "Boar", "card_image/quest/questCard4", 2);
 			addQuest("Repel the Saxxon Raiders", 2, "Saxon", "card_image/quest/questCard3", 2);
 

--- a/QUEST/Assets/script/Game.cs
+++ b/QUEST/Assets/script/Game.cs
@@ -216,11 +216,13 @@ public class Game : MonoBehaviour {
 					
 					if(_questReady == false){			//Quest is not Ready
 						if(checkQuest()){	
-							Debug.Log("Quest Here hehe");
 							_questReady = true;
 
 							// Flip the staged cards.
-
+							List<Card> stagedCards = getStagedCards();
+							for (int i = 0; i < stagedCards.Count; i++) {
+								stagedCards[i].flipCard(true);
+							}
 
 							updateHand(_turnId); 		 //Update Sponsor Hand based off of the UI
 							nextTurn(true,false);
@@ -501,7 +503,6 @@ public class Game : MonoBehaviour {
 		
 		List<Card> currHand = _players[playerId].hand;
 		Card currCard;
-		
 
 		//Set Player ID text
 		playerIdTxt.GetComponent<UnityEngine.UI.Text>().text = "Player ID : "+ (playerId+1).ToString(); //For User Friendly
@@ -544,11 +545,9 @@ public class Game : MonoBehaviour {
 				CardUI.GetComponent<AllyCard>().name    = currAlly.name;
 				CardUI.GetComponent<AllyCard>().asset   = currAlly.asset;
 			}
-
-
+				
 			Sprite card = Resources.Load<Sprite>(currCard.asset); //Card Sprite
 
-			//Debug.Log(card);
 			CardUI.gameObject.GetComponent<Image>().sprite = card;
 			CardUI.transform.SetParent(Hand.transform);
 


### PR DESCRIPTION
This PR fixes a problem where the new card being added to the stage wasn't actually the card that was in the players hand. Not it removes and stores the exact card object, and then adds that to the stage. This fixes a problem with dragging and allows flipping of cards to work properly.

Also changed `card.flipCard` to take a boolean which specifies if it's flipped or not.

This might also be the issue with players hands not removing cards, which I'll look into.