### PR TITLE
bug fixes to type check

### DIFF
--- a/QUEST/Assets/script/Deck.cs
+++ b/QUEST/Assets/script/Deck.cs
@@ -37,37 +37,37 @@ public class Deck{
 			/* Foe Load */
 
 			/* 7 Robber Knight */
-			addFoe("Robber Knight", 15, 15, false, "card_image/foe/foeCard1", 7);
+			addFoe("Robber Knight","Robber Knight", 15, 15, false, "card_image/foe/foeCard1", 7);
 
 			/* 5 Saxons */
-			addFoe("Saxons", 10, 20, false, "card_image/foe/foeCard2", 5);
+			addFoe("Saxons","Saxon", 10, 20, false, "card_image/foe/foeCard2", 5);
 
 			/* 4 Boar*/
-			addFoe("Boar", 5, 15, false, "card_image/foe/foeCard3", 4);
+			addFoe("Boar","Boar", 5, 15, false, "card_image/foe/foeCard3", 4);
 
 			/* 8 Thieves*/
-			addFoe("Thieves", 5, 5, false, "card_image/foe/foeCard4", 8);
+			addFoe("Thieves","Thieves", 5, 5, false, "card_image/foe/foeCard4", 8);
 
 			/* 2 Green Knight*/
-			addFoe("Green Knight", 25, 40, false, "card_image/foe/foeCard5", 2);
+			addFoe("Green Knight","Green Knight", 25, 40, false, "card_image/foe/foeCard5", 2);
 
 			/* 3 Black Knight */
-			addFoe("Black Knight", 25, 35, false, "card_image/foe/foeCard6", 3);
+			addFoe("Black Knight","Black Knight", 25, 35, false, "card_image/foe/foeCard6", 3);
 
 			/* 6 Evil Knight*/
-			addFoe("Evil Knight", 20, 30, false, "card_image/foe/foeCard7", 6);
+			addFoe("Evil Knight","Evil Knight", 20, 30, false, "card_image/foe/foeCard7", 6);
 
 			/* 8 Saxon Knight */
-			addFoe("Saxon Knight", 15, 25, false, "card_image/foe/foeCard8", 8);
+			addFoe("Saxon Knight","Saxon", 15, 25, false, "card_image/foe/foeCard8", 8);
 
 			/* 1 Dragon */
-			addFoe("Dragon", 50, 70, false, "card_image/foe/foeCard9", 1);
+			addFoe("Dragon","Dragon", 50, 70, false, "card_image/foe/foeCard9", 1);
 
 			/* 2 Giant */
-			addFoe("Giant", 40, 40, false, "card_image/foe/foeCard10", 2);
+			addFoe("Giant","Giant", 40, 40, false, "card_image/foe/foeCard10", 2);
 
 			/* 4 Mordred */
-			addFoe("Mordred", 30, 30, true, "card_image/foe/foeCard11", 4);
+			addFoe("Mordred","Mordred", 30, 30, true, "card_image/foe/foeCard11", 4);
 
 			/* Ally load */
 
@@ -133,9 +133,9 @@ public class Deck{
 	}
 
 	// Add a given amount of a foe to the deck.
-	void addFoe(string name, int loPower, int hiPower, bool special, string asset, int copies){
+	void addFoe(string name, string type, int loPower, int hiPower, bool special, string asset, int copies){
 		for (int i = 0; i < copies; i++) {
-			_cards.Add(new FoeCard(name, loPower, hiPower, special, asset));
+			_cards.Add(new FoeCard(name, type, loPower, hiPower, special, asset));
 		}
 	}
 

--- a/QUEST/Assets/script/FoeCard.cs
+++ b/QUEST/Assets/script/FoeCard.cs
@@ -9,6 +9,16 @@ public class FoeCard : AdventureCard
 	private bool _special;
 	private int _loPower;
 	private int _hiPower;
+	private string _type;
+
+	public string type{
+		get{
+			return this._type;
+		}
+		set{
+			this._type = value;
+		}
+	}
 
 	public bool special{
 		get{
@@ -39,8 +49,9 @@ public class FoeCard : AdventureCard
 
 
 
-	public FoeCard(string name, int loPower, int hiPower, bool special, string asset) {
+	public FoeCard(string name, string type,  int loPower, int hiPower, bool special, string asset) {
 		_name = name;
+		_type = type;
 		_loPower = loPower;
 		_hiPower = hiPower;
 		_special = special;
@@ -49,7 +60,7 @@ public class FoeCard : AdventureCard
 
 	// ToString Override for nicer printing.
 	public override string ToString(){
-		return "Foe card:\nName: " + _name + "\nLow Power: " + _loPower + "\nHigh Power: " + _hiPower +
+		return "Foe card:\nName: " + _name + "\n _type" + _type + "\nLow Power: " + _loPower + "\nHigh Power: " + _hiPower +
 			"/nSpecial" + _special;
 	}
 }

--- a/QUEST/Assets/script/Game.cs
+++ b/QUEST/Assets/script/Game.cs
@@ -122,7 +122,11 @@ public class Game : MonoBehaviour {
 			}
 			else if(currCard.GetType() == typeof(FoeCard)){
 				FoeCard currFoe = (FoeCard)currCard;
-				if(_questCard.featuredFoe == currFoe.name){	//Feature Foe Logic 
+
+				if(_questCard.featuredFoe == currFoe.type){	//Feature Foe Logic 
+					power = power + currFoe.hiPower;
+				}
+				else if(_questCard.featuredFoe == "*"){
 					power = power + currFoe.hiPower;
 				}
 				else{
@@ -531,6 +535,7 @@ public class Game : MonoBehaviour {
 				FoeCard currFoe = (FoeCard)currCard;
 				CardUI = Instantiate (FoeCard);
 				CardUI.GetComponent<FoeCard>().name    = currFoe.name;
+				CardUI.GetComponent<FoeCard>().type    = currFoe.type;
 				CardUI.GetComponent<FoeCard>().loPower = currFoe.loPower;
 				CardUI.GetComponent<FoeCard>().hiPower = currFoe.hiPower;
 				CardUI.GetComponent<FoeCard>().special = currFoe.special;


### PR DESCRIPTION
Changed foe constructor in "forCard" class to take another string, type string. Because saxons were name were not equal to the "featuredFoe". Changed the game stage valid function so that it uses the foe card "type" instead of "name" to compare to featured foe to see if it is equal. Also added if statement for when the featured foe is "*"(all foes) so that it uses the high values for all foes in the quest.

